### PR TITLE
fix: update clone directory name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Untuk menjalankan bot ini, Anda harus memiliki akun Discord Developer Portal. Ji
 Clone repositori ini ke perangkat Anda:
 ```bash
 git clone https://github.com/irfankurniawansuthiono/js-discord-game-bot.git
-cd DiscordGameBot
+cd js-discord-game-bot
 ```
 
 ### 2. Pasang Dependencies


### PR DESCRIPTION
Fix wrong directory name from `DiscordGameBot` to `js-discord-game-bot`